### PR TITLE
Fix error in parsing case-sensitive Id key

### DIFF
--- a/src/main/java/com/nirima/docker/client/model/ContainerInspectResponse.java
+++ b/src/main/java/com/nirima/docker/client/model/ContainerInspectResponse.java
@@ -15,7 +15,7 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ContainerInspectResponse {
 
-    @JsonProperty("ID")
+    @JsonProperty("Id")
     private String id;
 
     @JsonProperty("Created")


### PR DESCRIPTION
This was resulting in an invalid container ID in docker-plugin.

(see: http://docs.docker.io/reference/api/docker_remote_api_v1.0)
