### PR TITLE
Extend ContainerConfig with HostConfig

### DIFF
--- a/src/main/java/com/nirima/docker/client/model/ContainerConfig.java
+++ b/src/main/java/com/nirima/docker/client/model/ContainerConfig.java
@@ -2,6 +2,8 @@ package com.nirima.docker.client.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 import com.google.common.base.Objects;
 
 import java.io.Serializable;
@@ -30,6 +32,11 @@ public class ContainerConfig  implements Serializable {
     @JsonProperty("Env")          private String[]  env;
     @JsonProperty("Cmd")          private String[]  cmd;
 
+    @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
+    @JsonProperty("HostConfig")
+    private HostConfig hostConfig;
+    //@JsonProperty("HostConfig")   private HostConfig hostConfig;
+
     // Seems deprecated in later oocker APIs
     @JsonProperty("Dns")          private String[]  dns;
     @JsonProperty("Image")        private String    image;
@@ -44,6 +51,14 @@ public class ContainerConfig  implements Serializable {
     @JsonProperty("ExposedPorts")   private Map<String, ?> exposedPorts;
     
     @JsonProperty("OnBuild")   private int[] onBuild;
+
+    public HostConfig getHostConfig() {
+        return hostConfig;
+    }
+    public ContainerConfig setHostConfig(HostConfig hostConfig) {
+        this.hostConfig = hostConfig;
+        return this;
+    }
 
     public Map<String, ?> getExposedPorts() {
         return exposedPorts;
@@ -321,6 +336,7 @@ public class ContainerConfig  implements Serializable {
                 .add("domainName", domainName)
                 .add("exposedPorts", exposedPorts)
                 .add("onBuild", onBuild)
+                .add("hostConfig", hostConfig)
                 .toString();
     }
 }

--- a/src/main/java/com/nirima/docker/client/model/ContainerConfig.java
+++ b/src/main/java/com/nirima/docker/client/model/ContainerConfig.java
@@ -2,7 +2,6 @@ package com.nirima.docker.client.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import com.google.common.base.Objects;
 
@@ -31,12 +30,8 @@ public class ContainerConfig  implements Serializable {
     @JsonProperty("AttachStderr") private boolean   attachStderr = false;
     @JsonProperty("Env")          private String[]  env;
     @JsonProperty("Cmd")          private String[]  cmd;
-
-    @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
     @JsonProperty("HostConfig")
     private HostConfig hostConfig;
-    //@JsonProperty("HostConfig")   private HostConfig hostConfig;
-
     // Seems deprecated in later oocker APIs
     @JsonProperty("Dns")          private String[]  dns;
     @JsonProperty("Image")        private String    image;

--- a/src/main/java/com/nirima/docker/client/model/HostConfig.java
+++ b/src/main/java/com/nirima/docker/client/model/HostConfig.java
@@ -2,6 +2,7 @@ package com.nirima.docker.client.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Objects;
 import com.google.common.collect.ArrayListMultimap;
@@ -76,6 +77,7 @@ public class HostConfig implements Serializable {
     /**
      * Set up some port mappings
      * **/
+    @JsonIgnore
     public void setPortBindings(Iterable<PortMapping> portMappingCollection) {
 
         Multimap<String, PortBinding> bindings = ArrayListMultimap.create();


### PR DESCRIPTION
On my mission to enable volumes for the jenkins docker plugin this was needed to give the docker daemon the information needed to setup bind mounts right.
