### PR TITLE
Added support for --add-hosts (ExtraHosts) command. Supports multiple entries.

### DIFF
--- a/src/main/java/com/nirima/docker/client/model/ContainerConfig.java
+++ b/src/main/java/com/nirima/docker/client/model/ContainerConfig.java
@@ -29,6 +29,7 @@ public class ContainerConfig  implements Serializable {
     @JsonProperty("AttachStderr") private boolean   attachStderr = false;
     @JsonProperty("Env")          private String[]  env;
     @JsonProperty("Cmd")          private String[]  cmd;
+    @JsonProperty("ExtraHosts")   private String[]  extraHosts;
 
     // Seems deprecated in later oocker APIs
     @JsonProperty("Dns")          private String[]  dns;
@@ -227,6 +228,16 @@ public class ContainerConfig  implements Serializable {
         return this;
      }
 
+    public String[] getExtraHosts() {
+        return extraHosts;
+    }
+
+    public ContainerConfig setExtraHosts(String[] extraHosts) {
+        this.extraHosts = extraHosts;
+
+        return this;
+    }
+
     public String[] getDns() {
         return dns;
     }
@@ -310,6 +321,7 @@ public class ContainerConfig  implements Serializable {
                 .add("attachStderr", attachStderr)
                 .add("env", env)
                 .add("cmd", cmd)
+                .add("extraHosts", extraHosts)
                 .add("dns", dns)
                 .add("image", image)
                 .add("volumes", volumes)

--- a/src/main/java/com/nirima/docker/client/model/HostConfig.java
+++ b/src/main/java/com/nirima/docker/client/model/HostConfig.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  *
@@ -21,6 +22,7 @@ import java.util.Map;
  */
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class HostConfig implements Serializable {
+    private static final Logger LOGGER = Logger.getLogger("freddy");
 
     @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
     @JsonProperty("Binds")
@@ -56,6 +58,10 @@ public class HostConfig implements Serializable {
     @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
     @JsonProperty("VolumesFrom")
     private String[] volumesFrom;
+
+    @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
+    @JsonProperty("ExtraHosts")
+    private String[] extraHosts;
 
     public HostConfig() {
 
@@ -156,6 +162,20 @@ public class HostConfig implements Serializable {
         this.volumesFrom = volumesFrom;
     }
 
+    public String[] getExtraHosts() {
+        return extraHosts;
+    }
+
+    public void setExtraHosts(String[] extraHosts) {
+	try{
+	    LOGGER.info("gonna try to set.");
+            this.extraHosts = extraHosts;
+        }catch(Exception e){
+	    LOGGER.info("failed to set wtf");
+	    LOGGER.info(e.getMessage());
+	}
+    }
+
     public class LxcConf implements Serializable {
         @JsonProperty("Key")
         public String key;
@@ -190,6 +210,7 @@ public class HostConfig implements Serializable {
                 .add("portBindings", portBindings)
                 .add("privileged", privileged)
                 .add("publishAllPorts", publishAllPorts)
+		.add("extraHosts", extraHosts)
                 .add("dns", dns)
                 .add("volumesFrom", volumesFrom)
                 .toString();


### PR DESCRIPTION
From the v1.17 API doc.
ExtraHosts - A list of hostnames/IP mappings to be added to the container's /etc/hosts file. Specified in the form ["hostname:IP"].
